### PR TITLE
Allow for SockJS; removed dom import to reduce file sizes; made WebSocket an interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ package main
 
 import (
 	"github.com/gopherjs/gopherjs/js"
-	"github.com/liamcurry/websocket"
+	"github.com/gopherjs/websocket"
 	"honnef.co/go/js/console"
 )
 
@@ -33,8 +33,8 @@ func main() {
 		console.Log("closed", obj)
 	})
 
-	master.OnMessage(func(e *dom.MessageEvent) {
-		console.Log("message", e)
+	master.OnMessage(func(obj js.Object) {
+		console.Log("message", obj)
 	})
 }
 ```

--- a/README.md
+++ b/README.md
@@ -4,3 +4,37 @@ websocket
 Package websocket will provide GopherJS bindings for the WebSocket API.
 
 It is currently in development and should not be considered stable. The public API is unfinished and will change.
+
+Example
+-------
+
+```go
+package main
+
+import (
+	"github.com/gopherjs/gopherjs/js"
+	"github.com/liamcurry/websocket"
+	"honnef.co/go/js/console"
+)
+
+func main() {
+	master := websocket.New("http://localhost:9001/ws")
+	//master := websocket.NewWithGlobal("SockJS", "http://localhost:9001/ws")
+
+	master.OnOpen(func(obj js.Object) {
+		console.Log("opened", obj)
+	})
+
+	master.OnError(func(obj js.Object) {
+		console.Log("error", obj)
+	})
+
+	master.OnClose(func(obj js.Object) {
+		console.Log("closed", obj)
+	})
+
+	master.OnMessage(func(e *dom.MessageEvent) {
+		console.Log("message", e)
+	})
+}
+```

--- a/README.md
+++ b/README.md
@@ -18,22 +18,22 @@ import (
 )
 
 func main() {
-	master := websocket.New("http://localhost:9001/ws")
-	//master := websocket.NewWithGlobal("SockJS", "http://localhost:9001/ws")
+	ws := websocket.New("http://localhost:9001/ws")
+	//ws := websocket.NewWithGlobal("SockJS", "http://localhost:9001/ws")
 
-	master.OnOpen(func(obj js.Object) {
+	ws.OnOpen(func(obj js.Object) {
 		console.Log("opened", obj)
 	})
 
-	master.OnError(func(obj js.Object) {
+	ws.OnError(func(obj js.Object) {
 		console.Log("error", obj)
 	})
 
-	master.OnClose(func(obj js.Object) {
+	ws.OnClose(func(obj js.Object) {
 		console.Log("closed", obj)
 	})
 
-	master.OnMessage(func(obj js.Object) {
+	ws.OnMessage(func(obj js.Object) {
 		console.Log("message", obj)
 	})
 }

--- a/main.go
+++ b/main.go
@@ -2,8 +2,6 @@ package websocket
 
 import (
 	"errors"
-
-	"honnef.co/go/js/console"
 	"honnef.co/go/js/dom"
 
 	"github.com/gopherjs/gopherjs/js"
@@ -35,7 +33,6 @@ type webSocket struct {
 
 // NewWithGlobal allows for customizing the global variable on the window.
 func NewWithGlobal(global, url string) WebSocket {
-	console.Log("creating a new websocket")
 	object := js.Global.Get(global).New(url)
 	ws := &webSocket{Object: object}
 	return ws
@@ -43,7 +40,6 @@ func NewWithGlobal(global, url string) WebSocket {
 
 // New creates a new websocket.
 func New(url string) WebSocket {
-	console.Log("creating a new websocket", "url")
 	return NewWithGlobal("WebSocket", url)
 }
 

--- a/main.go
+++ b/main.go
@@ -3,6 +3,7 @@ package websocket
 import (
 	"errors"
 
+	"honnef.co/go/js/console"
 	"honnef.co/go/js/dom"
 
 	"github.com/gopherjs/gopherjs/js"
@@ -17,30 +18,56 @@ const (
 	closed                       // The connection is closed or couldn't be opened.
 )
 
-type WebSocket struct {
+// A WebSocket is anything that implements the websockets interface.
+// http://www.w3.org/TR/websockets/#websocket
+type WebSocket interface {
+	OnOpen(listener func(js.Object))
+	OnError(listener func(js.Object))
+	OnClose(listener func(js.Object))
+	OnMessage(listener func(*dom.MessageEvent))
+	Send(data string) error
+	Close() error
+}
+
+type webSocket struct {
 	js.Object
 }
 
-func New(url string) *WebSocket {
-	object := js.Global.Get("WebSocket").New(url)
-	ws := &WebSocket{Object: object}
+// NewWithGlobal allows for customizing the global variable on the window.
+func NewWithGlobal(global, url string) WebSocket {
+	console.Log("creating a new websocket")
+	object := js.Global.Get(global).New(url)
+	ws := &webSocket{Object: object}
 	return ws
 }
 
-func (ws *WebSocket) OnOpen(listener func(js.Object)) {
+// New creates a new websocket.
+func New(url string) WebSocket {
+	console.Log("creating a new websocket", "url")
+	return NewWithGlobal("WebSocket", url)
+}
+
+func (ws *webSocket) OnOpen(listener func(js.Object)) {
 	ws.Object.Set("onopen", listener)
 }
 
-func (ws *WebSocket) OnClose(listener func(js.Object)) {
+func (ws *webSocket) OnError(listener func(js.Object)) {
+	ws.Object.Set("onerror", listener)
+}
+
+func (ws *webSocket) OnClose(listener func(js.Object)) {
 	ws.Object.Set("onclose", listener)
 }
 
-func (ws *WebSocket) OnMessage(listener func(messageEvent *dom.MessageEvent)) {
+func (ws *webSocket) OnMessage(listener func(messageEvent *dom.MessageEvent)) {
 	wrapper := func(object js.Object) { listener(&dom.MessageEvent{BasicEvent: &dom.BasicEvent{Object: object}}) }
 	ws.Object.Set("onmessage", wrapper)
 }
 
-func (ws *WebSocket) Send(data string) (err error) {
+// Thrown when attempting to send data on a websocket that isn't open.
+var ErrInvalidState = errors.New("invalid state error")
+
+func (ws *webSocket) Send(data string) (err error) {
 	defer func() {
 		e := recover()
 		if e == nil {
@@ -48,7 +75,7 @@ func (ws *WebSocket) Send(data string) (err error) {
 		}
 		if jsErr, ok := e.(*js.Error); ok && jsErr != nil {
 			println(jsErr.Object.Get("name").Str() == "InvalidStateError")
-			err = errors.New("InvalidStateError")
+			err = ErrInvalidState
 		} else {
 			panic(e)
 		}
@@ -57,7 +84,7 @@ func (ws *WebSocket) Send(data string) (err error) {
 	return nil
 }
 
-func (ws *WebSocket) Close() (err error) {
+func (ws *webSocket) Close() (err error) {
 	defer func() {
 		e := recover()
 		if e == nil {

--- a/main.go
+++ b/main.go
@@ -2,7 +2,6 @@ package websocket
 
 import (
 	"errors"
-	"honnef.co/go/js/dom"
 
 	"github.com/gopherjs/gopherjs/js"
 )
@@ -22,7 +21,7 @@ type WebSocket interface {
 	OnOpen(listener func(js.Object))
 	OnError(listener func(js.Object))
 	OnClose(listener func(js.Object))
-	OnMessage(listener func(*dom.MessageEvent))
+	OnMessage(listener func(js.Object))
 	Send(data string) error
 	Close() error
 }
@@ -55,8 +54,8 @@ func (ws *webSocket) OnClose(listener func(js.Object)) {
 	ws.Object.Set("onclose", listener)
 }
 
-func (ws *webSocket) OnMessage(listener func(messageEvent *dom.MessageEvent)) {
-	wrapper := func(object js.Object) { listener(&dom.MessageEvent{BasicEvent: &dom.BasicEvent{Object: object}}) }
+func (ws *webSocket) OnMessage(listener func(js.Object)) {
+	wrapper := func(obj js.Object) { listener(obj) }
 	ws.Object.Set("onmessage", wrapper)
 }
 


### PR DESCRIPTION
This merge adds/changes a few things:
- Added `websocket.NewWithGlobal` function to allow specifying the variable on the window.
- Added example usage to the readme.
- Changed `websocket.WebSocket` from a struct to an interface.
- Added `OnError` function.
- Replaced `dom.MessageEvent` with `js.Object` to avoid huge file sizes (see [this issue over at gopherjs/gopherjs](https://github.com/gopherjs/gopherjs/issues/136))
