### PR TITLE
websocket.Conn should fulfill net.Conn

### DIFF
--- a/addr.go
+++ b/addr.go
@@ -6,10 +6,10 @@ package websocket
 
 import "net/url"
 
-// Addr represents the address of a WebSocket connection.
-type Addr struct {
+// addr represents the address of a WebSocket connection.
+type addr struct {
 	*url.URL
 }
 
 // Network returns the network type for a WebSocket, "websocket".
-func (addr *Addr) Network() string { return "websocket" }
+func (addr *addr) Network() string { return "websocket" }

--- a/conn.go
+++ b/conn.go
@@ -278,7 +278,7 @@ func (c *Conn) RemoteAddr() net.Addr {
 		// TODO(nightexcessive): Should we be panicking for this?
 		panic(err)
 	}
-	return &Addr{wsURL}
+	return &addr{wsURL}
 }
 
 // SetDeadline sets the read and write deadlines associated with the connection.

--- a/conn.go
+++ b/conn.go
@@ -8,6 +8,7 @@ import (
 	"bytes"
 	"fmt"
 	"io"
+	"net"
 	"net/url"
 	"time"
 
@@ -261,7 +262,7 @@ func (c *Conn) WriteString(s string) (n int, err error) {
 // LocalAddr would typically return the local network address, but due to
 // limitations in the JavaScript API, it is unable to. Calling this method will
 // cause a panic.
-func (c *Conn) LocalAddr() *Addr {
+func (c *Conn) LocalAddr() net.Addr {
 	// BUG(nightexcessive): Conn.LocalAddr() panics because the underlying
 	// JavaScript API has no way of figuring out the local address.
 
@@ -271,7 +272,7 @@ func (c *Conn) LocalAddr() *Addr {
 
 // RemoteAddr returns the remote network address, based on
 // websocket.WebSocket.URL.
-func (c *Conn) RemoteAddr() *Addr {
+func (c *Conn) RemoteAddr() net.Addr {
 	wsURL, err := url.Parse(c.URL)
 	if err != nil {
 		// TODO(nightexcessive): Should we be panicking for this?


### PR DESCRIPTION
Now that gopherjs/gopherjs#123 is fixed, I've made a couple of simple changes to make websocket.Conn fulfill the net.Conn interface. Looking for a code review.

As websocket.Addr doesn't need to be exported anymore, I felt that it added clutter to the docs. As such, I've unexported it.