### PR TITLE
don't drop CloseEvent silently

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -66,10 +66,6 @@ func (e *closeError) Error() string {
 			if !ok {
 				reason = "Unknown reason"
 			}
-
-			if e.Code == 1010 {
-				reason += "\nSpecifically, the extensions that are needed are: " + e.Reason
-			}
 		}
 
 	}

--- a/conn.go
+++ b/conn.go
@@ -24,14 +24,36 @@ func beginHandlerOpen(ch chan error, removeHandlers func()) func(ev *js.Object) 
 	}
 }
 
+// closeErrorMap maps Close frame status codes to their string explanation
+// See http://tools.ietf.org/html/rfc6455#section-7.4.1
+var closeErrorMap = map[int]string{
+	1000: "Normal closure, meaning that the purpose for which the connection was established has been fulfilled.",
+	1001: "An endpoint is \"going away\", such as a server going down or a browser having navigated away from a page.",
+	1002: "An endpoint is terminating the connection due to a protocol error",
+	1003: "An endpoint is terminating the connection because it has received a type of data it cannot accept (e.g., an endpoint that understands only text data MAY send this if it receives a binary message).",
+	1004: "Reserved. The specific meaning might be defined in the future.",
+	1005: "No status code was actually present.",
+	1006: "The connection was closed abnormally, e.g., without sending or receiving a Close control frame",
+	1007: "An endpoint is terminating the connection because it has received data within a message that was not consistent with the type of the message (e.g., non-UTF-8 [http://tools.ietf.org/html/rfc3629] data within a text message).",
+	1008: "An endpoint is terminating the connection because it has received a message that \"violates its policy\". This reason is given either if there is no other sutible reason, or if there is a need to hide specific details about the policy.",
+	1009: "An endpoint is terminating the connection because it has received a message that is too big for it to process.",
+	// Note that this status code is not used by the server, because it can fail the WebSocket handshake instead
+	1010: "An endpoint (client) is terminating the connection because it has expected the server to negotiate one or more extension, but the server didn't return them in the response message of the WebSocket handshake.",
+	1011: "A server is terminating the connection because it encountered an unexpected condition that prevented it from fulfilling the request.",
+	1015: "The connection was closed due to a failure to perform a TLS handshake (e.g., the server certificate can't be verified).",
+}
+
 // closeError allows a CloseEvent to be used as an error.
 type closeError struct {
 	*dom.CloseEvent
 }
 
 func (e *closeError) Error() string {
-	var cleanStmt string
-	var reason string // cant override the event's reason
+	var (
+		cleanStmt string
+		reason    string // cant override the event's reason
+		ok        bool
+	)
 	if e.WasClean {
 		cleanStmt = "clean"
 	} else {
@@ -40,40 +62,17 @@ func (e *closeError) Error() string {
 		if e.Reason != "" {
 			console.Warn("original Reason:", e.Reason)
 			reason = e.Reason
+		} else {
+			reason, ok = closeErrorMap[e.Code]
+			if !ok {
+				reason = "Unknown reason"
+			}
+
+			if e.Code == 1010 {
+				reason += "\nSpecifically, the extensions that are needed are: " + e.Reason
+			}
 		}
 
-		// taken from http://stackoverflow.com/a/28396165
-		// See http://tools.ietf.org/html/rfc6455#section-7.4.1
-		switch e.Code {
-		case 1000:
-			reason = "Normal closure, meaning that the purpose for which the connection was established has been fulfilled."
-		case 1001:
-			reason = "An endpoint is \"going away\", such as a server going down or a browser having navigated away from a page."
-		case 1002:
-			reason = "An endpoint is terminating the connection due to a protocol error"
-		case 1003:
-			reason = "An endpoint is terminating the connection because it has received a type of data it cannot accept (e.g., an endpoint that understands only text data MAY send this if it receives a binary message)."
-		case 1004:
-			reason = "Reserved. The specific meaning might be defined in the future."
-		case 1005:
-			reason = "No status code was actually present."
-		case 1006:
-			reason = "The connection was closed abnormally, e.g., without sending or receiving a Close control frame"
-		case 1007:
-			reason = "An endpoint is terminating the connection because it has received data within a message that was not consistent with the type of the message (e.g., non-UTF-8 [http://tools.ietf.org/html/rfc3629] data within a text message)."
-		case 1008:
-			reason = "An endpoint is terminating the connection because it has received a message that \"violates its policy\". This reason is given either if there is no other sutible reason, or if there is a need to hide specific details about the policy."
-		case 1009:
-			reason = "An endpoint is terminating the connection because it has received a message that is too big for it to process."
-		case 1010: // Note that this status code is not used by the server, because it can fail the WebSocket handshake instead
-			reason = "An endpoint (client) is terminating the connection because it has expected the server to negotiate one or more extension, but the server didn't return them in the response message of the WebSocket handshake. <br /> Specifically, the extensions that are needed are: " + reason
-		case 1011:
-			reason = "A server is terminating the connection because it encountered an unexpected condition that prevented it from fulfilling the request."
-		case 1015:
-			reason = "The connection was closed due to a failure to perform a TLS handshake (e.g., the server certificate can't be verified)."
-		default:
-			reason = "Unknown reason"
-		}
 	}
 
 	return fmt.Sprintf("CloseEvent: (%s) (%d) %s", cleanStmt, e.Code, reason)

--- a/conn.go
+++ b/conn.go
@@ -60,7 +60,6 @@ func (e *closeError) Error() string {
 		cleanStmt = "unclean"
 
 		if e.Reason != "" {
-			console.Warn("original Reason:", e.Reason)
 			reason = e.Reason
 		} else {
 			reason, ok = closeErrorMap[e.Code]
@@ -165,8 +164,6 @@ func (c *Conn) onMessage(event *js.Object) {
 
 func (c *Conn) onClose(event *js.Object) {
 	go func() {
-		console.Warn("close event captured")
-		console.Dir(event)
 		if ce, ok := dom.WrapEvent(event).(*dom.CloseEvent); ok {
 			err := &closeError{CloseEvent: ce}
 			console.Error(err.Error())


### PR DESCRIPTION
Hi,

[currently](https://github.com/gopherjs/websocket/blob/4fa2f19101270dd164ee7ab61af90c2a03f87067/conn.go#L126) the event object of the close event is silently ignored and dropped. I use a `Conn` from this package to build a `net/rpc` client and stumbled over this when I saw that uses of a closed connection returned an empty error. I can create a more verbose reproduction if needed.

Furthermore, the reason string was empty but the code was set (for me at least on Linux with Chromium42 and Firefox37). I found a [post on stackoverflow](http://stackoverflow.com/a/28396165) which had compiled the code>reason mapping from RFC6455.

I think a proper fix should also fix or improve #7 but I wanted feedback first on how to progress on both cleanly.
