### PR TITLE
websocketjs: Use Normal Closure (1000) close code in WebSocket.Close.

### DIFF
--- a/test/test/index.go
+++ b/test/test/index.go
@@ -58,13 +58,13 @@ func main() {
 
 		ws.AddEventListener("close", false, func(ev *js.Object) {
 			const (
-				CloseNormal            = 1000
-				CloseNoReasonSpecified = 1005 // IE10 hates it when the server closes without sending a close reason
+				CloseNormalClosure    = 1000
+				CloseNoStatusReceived = 1005 // IE10 hates it when the server closes without sending a close reason
 			)
 
 			closeEventCode := ev.Get("code").Int()
 
-			if closeEventCode != CloseNormal && closeEventCode != CloseNoReasonSpecified {
+			if closeEventCode != CloseNormalClosure && closeEventCode != CloseNoStatusReceived {
 				qunit.Ok(false, fmt.Sprintf("WebSocket close was not clean (code %d)", closeEventCode))
 				qunit.Start()
 				return

--- a/websocketjs/websocketjs.go
+++ b/websocketjs/websocketjs.go
@@ -160,6 +160,17 @@ func (ws *WebSocket) Close() (err error) {
 			panic(e)
 		}
 	}()
-	ws.Object.Call("close")
+
+	// Use close code closeNormalClosure to indicate that the purpose
+	// for which the connection was established has been fulfilled.
+	// See https://tools.ietf.org/html/rfc6455#section-7.4.
+	ws.Object.Call("close", closeNormalClosure)
 	return
 }
+
+// Close codes defined in RFC 6455, section 11.7.
+const (
+	// 1000 indicates a normal closure, meaning that the purpose for
+	// which the connection was established has been fulfilled.
+	closeNormalClosure = 1000
+)


### PR DESCRIPTION
When no status code is provided, Close will default to 1005, indicating that the websocket was closed with no status code. In the case of the Close function, the user has requested a termination of the websocket and the status code should indicate that.