### PR TITLE
Add support for WebSocket sub-protocols

### DIFF
--- a/conn.go
+++ b/conn.go
@@ -62,10 +62,11 @@ var errDeadlineReached = &deadlineErr{}
 // TODO(nightexcessive): Add a Dial function that allows a deadline to be
 // specified.
 
-// Dial opens a new WebSocket connection. It will block until the connection is
-// established or fails to connect.
-func Dial(url string) (net.Conn, error) {
-	ws, err := websocketjs.New(url)
+// Dial opens a new WebSocket connection, setting the optional sub-protocols in
+// the header. It will block until the connection is established or fails to
+// connect.
+func Dial(url string, protocols ...string) (net.Conn, error) {
+	ws, err := websocketjs.New(url, protocols...)
 	if err != nil {
 		return nil, err
 	}

--- a/test/test/index.go
+++ b/test/test/index.go
@@ -159,6 +159,90 @@ func main() {
 
 		return nil
 	})
+	qunit.AsyncTest("Single Subprotocol", func() interface{} {
+		qunit.Expect(3)
+
+		go func() {
+			defer qunit.Start()
+
+			ws, err := websocket.Dial(wsBaseURL+"subprotocols", "mqttv3.1")
+			if err != nil {
+				qunit.Ok(false, fmt.Sprintf("Error opening WebSocket: %s", err))
+				return
+			}
+
+			qunit.Ok(true, "WebSocket opened")
+
+			var expectedData = []byte("mqttv3.1")
+
+			receivedData := make([]byte, len(expectedData))
+			n, err := ws.Read(receivedData)
+			if err != nil {
+				qunit.Ok(false, fmt.Sprintf("Error in first read: %s", err))
+				return
+			}
+			receivedData = receivedData[:n]
+
+			if !bytes.Equal(receivedData, expectedData) {
+				qunit.Ok(false, fmt.Sprintf("Received data did not match expected data. Got % x, expected % x.", receivedData, expectedData))
+			} else {
+				qunit.Ok(true, fmt.Sprintf("Received data: % x", receivedData))
+			}
+
+			_, err = ws.Read(receivedData)
+			if err == io.EOF {
+				qunit.Ok(true, "Received EOF")
+			} else if err != nil {
+				qunit.Ok(false, fmt.Sprintf("Unexpected error in second read: %s", err))
+			} else {
+				qunit.Ok(false, "Expected EOF in second read, got no error")
+			}
+		}()
+
+		return nil
+	})
+	qunit.AsyncTest("Multiple Subprotocols", func() interface{} {
+		qunit.Expect(3)
+
+		go func() {
+			defer qunit.Start()
+
+			ws, err := websocket.Dial(wsBaseURL+"subprotocols", "mqttv3.1", "mqtt")
+			if err != nil {
+				qunit.Ok(false, fmt.Sprintf("Error opening WebSocket: %s", err))
+				return
+			}
+
+			qunit.Ok(true, "WebSocket opened")
+
+			var expectedData = []byte("mqtt")
+
+			receivedData := make([]byte, len(expectedData))
+			n, err := ws.Read(receivedData)
+			if err != nil {
+				qunit.Ok(false, fmt.Sprintf("Error in first read: %s", err))
+				return
+			}
+			receivedData = receivedData[:n]
+
+			if !bytes.Equal(receivedData, expectedData) {
+				qunit.Ok(false, fmt.Sprintf("Received data did not match expected data. Got % x, expected % x.", receivedData, expectedData))
+			} else {
+				qunit.Ok(true, fmt.Sprintf("Received data: % x", receivedData))
+			}
+
+			_, err = ws.Read(receivedData)
+			if err == io.EOF {
+				qunit.Ok(true, "Received EOF")
+			} else if err != nil {
+				qunit.Ok(false, fmt.Sprintf("Unexpected error in second read: %s", err))
+			} else {
+				qunit.Ok(false, "Expected EOF in second read, got no error")
+			}
+		}()
+
+		return nil
+	})
 	qunit.AsyncTest("Timeout", func() interface{} {
 		qunit.Expect(2)
 

--- a/websocketjs/websocketjs.go
+++ b/websocketjs/websocketjs.go
@@ -65,9 +65,9 @@ const (
 	Closed ReadyState = 3
 )
 
-// New creates a new low-level WebSocket. It immediately returns the new
-// WebSocket.
-func New(url string) (ws *WebSocket, err error) {
+// New creates a new low-level WebSocket, setting the optional sub-protocols in
+// the header. It immediately returns the new WebSocket.
+func New(url string, protocols ...string) (ws *WebSocket, err error) {
 	defer func() {
 		e := recover()
 		if e == nil {
@@ -81,7 +81,15 @@ func New(url string) (ws *WebSocket, err error) {
 		}
 	}()
 
-	object := js.Global.Get("WebSocket").New(url)
+	args := []interface{}{url}
+	switch {
+	case len(protocols) == 1:
+		args = append(args, protocols[0])
+	case len(protocols) > 1:
+		args = append(args, protocols)
+	}
+
+	object := js.Global.Get("WebSocket").New(args...)
 
 	ws = &WebSocket{
 		Object: object,


### PR DESCRIPTION
This Pull Request adds support for the optional `protocols` parameter to the `WebSocket` constructor. Both the "protocol string" and "array of protocol strings" variants are supported, depending on the number of protocols passed to `websocket.Dial` or `websocketjs.New`.